### PR TITLE
fix user-select for webkit browsers

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -7,6 +7,7 @@
   --toolbar-size: 60px;
   padding: var(--app-padding);
   box-sizing: border-box;
+  -webkit-user-select: none;
   user-select: none;
 
   &:not(.isVertical) {


### PR DESCRIPTION
Unfortunately [Safari still needs webkit prefix](https://caniuse.com/?search=user-select) for `user-select`